### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   global: # global settings for all jobs
     - ROS_REPO=ros
     - UPSTREAM_WORKSPACE=".travis.rosinstall"
+    - NOT_TEST_BUILD=true
+    - DEBUG_BASH=true
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix:
     - ROS_DISTRO="kinetic" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
   global: # global settings for all jobs
     - ROS_REPO=ros
     - UPSTREAM_WORKSPACE=".travis.rosinstall"
-    - NOT_TEST_BUILD=true
-    - DEBUG_BASH=true
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix:
     - ROS_DISTRO="kinetic" 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(catkin REQUIRED COMPONENTS
   nav_msgs
   robotont_msgs
   tf
-  cmake_modules
   serial
 )
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>robotont_driver</name>
   <version>0.0.1</version>
   <description>The robotont_driver package</description>

--- a/package.xml
+++ b/package.xml
@@ -30,16 +30,16 @@
   <build_depend>tf</build_depend>
   <build_depend>serial</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>robotont_description</run_depend>
-  <run_depend>robotont_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>serial</run_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>robotont_description</exec_depend>
+  <exec_depend>robotont_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>serial</exec_depend>
 
   <export>
     <!-- Other tools can request additional information be placed here -->


### PR DESCRIPTION
Travis was failing because of the deprecated cmake_modules package that was left in CMakeLists.txt.