### PR TITLE
io_service -> io_context

### DIFF
--- a/include/io_context/io_context.hpp
+++ b/include/io_context/io_context.hpp
@@ -66,7 +66,7 @@ public:
   IoContext(const IoContext &) = delete;
   IoContext & operator=(const IoContext &) = delete;
 
-  asio::io_service & ios() const;
+  asio::io_context & ios() const;
 
   bool isServiceStopped();
   uint32_t serviceThreadCount();
@@ -76,12 +76,12 @@ public:
   template<class F>
   void post(F f)
   {
-    ios().post(f);
+    asio::post(ios(), f);
   }
 
 private:
-  std::shared_ptr<asio::io_service> m_ios;
-  std::shared_ptr<asio::io_service::work> m_work;
+  std::shared_ptr<asio::io_context> m_ios;
+  std::shared_ptr<asio::executor_work_guard<asio::io_context::executor_type>> m_work;
   std::shared_ptr<drivers::common::thread_group> m_ios_thread_workers;
 };
 


### PR DESCRIPTION
Hi,

This fix build for asio 1.36.

`io_service` has been deprecated for at least 9 years (ref. blame https://github.com/boostorg/asio/blame/995eeab56906ab0a1f614602aa0dee9ee88bf8cb/include/boost/asio/io_service.hpp), and removed in https://github.com/boostorg/asio/commit/ec0908c562102915423d8bd7aefd3079efbb6c86